### PR TITLE
Update samples by using stable version of Flutter

### DIFF
--- a/example/lib/accessibility/neumorphic_accessibility.dart
+++ b/example/lib/accessibility/neumorphic_accessibility.dart
@@ -71,7 +71,7 @@ class __PageState extends State<_Page> {
                     style: ElevatedButton.styleFrom(
                       shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12)),
-                      backgroundColor: Theme.of(context).colorScheme.secondary,
+                      // backgroundColor: Theme.of(context).colorScheme.secondary,
                     ),
                     child: Text(
                       "back",
@@ -127,11 +127,12 @@ class __PageState extends State<_Page> {
                   padding: const EdgeInsets.all(8.0),
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12)),
-                        backgroundColor: selectedConfiguratorIndex == 0
-                            ? buttonActiveColor
-                            : buttonInnactiveColor),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12)),
+                      // backgroundColor: selectedConfiguratorIndex == 0
+                      //     ? buttonActiveColor
+                      //     : buttonInnactiveColor
+                    ),
                     child: Text(
                       "Style",
                       style: TextStyle(
@@ -154,11 +155,12 @@ class __PageState extends State<_Page> {
                   padding: const EdgeInsets.all(8.0),
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12)),
-                        backgroundColor: selectedConfiguratorIndex == 1
-                            ? buttonActiveColor
-                            : buttonInnactiveColor),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12)),
+                      // backgroundColor: selectedConfiguratorIndex == 1
+                      //     ? buttonActiveColor
+                      //     : buttonInnactiveColor
+                    ),
                     child: Text(
                       "Element",
                       style: TextStyle(
@@ -183,9 +185,9 @@ class __PageState extends State<_Page> {
                     style: ElevatedButton.styleFrom(
                       shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12)),
-                      backgroundColor: selectedConfiguratorIndex == 2
-                          ? buttonActiveColor
-                          : buttonInnactiveColor,
+                      // backgroundColor: selectedConfiguratorIndex == 2
+                      //     ? buttonActiveColor
+                      //     : buttonInnactiveColor,
                     ),
                     child: Text(
                       "Border",
@@ -528,9 +530,9 @@ class __PageState extends State<_Page> {
               style: ElevatedButton.styleFrom(
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12)),
-                backgroundColor: shape == NeumorphicShape.concave
-                    ? buttonActiveColor
-                    : buttonInnactiveColor,
+                // backgroundColor: shape == NeumorphicShape.concave
+                //     ? buttonActiveColor
+                //     : buttonInnactiveColor,
               ),
               onPressed: () {
                 setState(() {
@@ -551,9 +553,9 @@ class __PageState extends State<_Page> {
               style: ElevatedButton.styleFrom(
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12)),
-                backgroundColor: shape == NeumorphicShape.convex
-                    ? buttonActiveColor
-                    : buttonInnactiveColor,
+                // backgroundColor: shape == NeumorphicShape.convex
+                //     ? buttonActiveColor
+                //     : buttonInnactiveColor,
               ),
               onPressed: () {
                 setState(() {
@@ -574,9 +576,9 @@ class __PageState extends State<_Page> {
               style: ElevatedButton.styleFrom(
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12)),
-                backgroundColor: shape == NeumorphicShape.flat
-                    ? buttonActiveColor
-                    : buttonInnactiveColor,
+                // backgroundColor: shape == NeumorphicShape.flat
+                //     ? buttonActiveColor
+                //     : buttonInnactiveColor,
               ),
               onPressed: () {
                 setState(() {

--- a/example/lib/playground/neumorphic_playground.dart
+++ b/example/lib/playground/neumorphic_playground.dart
@@ -72,7 +72,7 @@ class __PageState extends State<_Page> {
               padding: const EdgeInsets.only(left: 8.0, right: 8.0, top: 8.0),
               child: ElevatedButton(
                 style: ElevatedButton.styleFrom(
-                    backgroundColor: Theme.of(context).colorScheme.secondary,
+                    // backgroundColor: Theme.of(context).colorScheme.secondary,
                     shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(12))),
                 child: const Text(
@@ -127,9 +127,9 @@ class __PageState extends State<_Page> {
                   padding: const EdgeInsets.all(8.0),
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                        backgroundColor: selectedConfiguratorIndex == 0
-                            ? buttonActiveColor
-                            : buttonInnactiveColor,
+                        // backgroundColor: selectedConfiguratorIndex == 0
+                        //     ? buttonActiveColor
+                        //     : buttonInnactiveColor,
                         shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(12))),
                     child: Text(
@@ -154,9 +154,9 @@ class __PageState extends State<_Page> {
                   padding: const EdgeInsets.all(8.0),
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                        backgroundColor: selectedConfiguratorIndex == 1
-                            ? buttonActiveColor
-                            : buttonInnactiveColor,
+                        // backgroundColor: selectedConfiguratorIndex == 1
+                        //     ? buttonActiveColor
+                        //     : buttonInnactiveColor,
                         shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(12))),
                     child: Text(
@@ -181,9 +181,9 @@ class __PageState extends State<_Page> {
                   padding: const EdgeInsets.all(8.0),
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                        backgroundColor: selectedConfiguratorIndex == 2
-                            ? buttonActiveColor
-                            : buttonInnactiveColor,
+                        // backgroundColor: selectedConfiguratorIndex == 2
+                        //     ? buttonActiveColor
+                        //     : buttonInnactiveColor,
                         shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(12))),
                     child: Text(
@@ -636,9 +636,9 @@ class __PageState extends State<_Page> {
             padding: const EdgeInsets.all(8.0),
             child: ElevatedButton(
               style: ElevatedButton.styleFrom(
-                  backgroundColor: boxShape.isRoundRect
-                      ? buttonActiveColor
-                      : buttonInnactiveColor,
+                  // backgroundColor: boxShape.isRoundRect
+                  //     ? buttonActiveColor
+                  //     : buttonInnactiveColor,
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12))),
               onPressed: () {
@@ -662,9 +662,9 @@ class __PageState extends State<_Page> {
             padding: const EdgeInsets.all(8.0),
             child: ElevatedButton(
               style: ElevatedButton.styleFrom(
-                  backgroundColor: boxShape.isBeveled
-                      ? buttonActiveColor
-                      : buttonInnactiveColor,
+                  // backgroundColor: boxShape.isBeveled
+                  //     ? buttonActiveColor
+                  //     : buttonInnactiveColor,
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12))),
               onPressed: () {
@@ -688,9 +688,9 @@ class __PageState extends State<_Page> {
             padding: const EdgeInsets.all(8.0),
             child: ElevatedButton(
               style: ElevatedButton.styleFrom(
-                  backgroundColor: boxShape.isCircle
-                      ? buttonActiveColor
-                      : buttonInnactiveColor,
+                  // backgroundColor: boxShape.isCircle
+                  //     ? buttonActiveColor
+                  //     : buttonInnactiveColor,
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12))),
               onPressed: () {
@@ -713,9 +713,9 @@ class __PageState extends State<_Page> {
             padding: const EdgeInsets.all(8.0),
             child: ElevatedButton(
               style: ElevatedButton.styleFrom(
-                  backgroundColor: boxShape.isStadium
-                      ? buttonActiveColor
-                      : buttonInnactiveColor,
+                  // backgroundColor: boxShape.isStadium
+                  //     ? buttonActiveColor
+                  //     : buttonInnactiveColor,
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12))),
               onPressed: () {
@@ -738,9 +738,9 @@ class __PageState extends State<_Page> {
             padding: const EdgeInsets.all(8.0),
             child: ElevatedButton(
               style: ElevatedButton.styleFrom(
-                  backgroundColor: boxShape.isCustomPath
-                      ? buttonActiveColor
-                      : buttonInnactiveColor,
+                  // backgroundColor: boxShape.isCustomPath
+                  //     ? buttonActiveColor
+                  //     : buttonInnactiveColor,
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12))),
               onPressed: () {
@@ -778,9 +778,9 @@ class __PageState extends State<_Page> {
             padding: const EdgeInsets.all(8.0),
             child: ElevatedButton(
               style: ElevatedButton.styleFrom(
-                  backgroundColor: shape == NeumorphicShape.concave
-                      ? buttonActiveColor
-                      : buttonInnactiveColor,
+                  // backgroundColor: shape == NeumorphicShape.concave
+                  //     ? buttonActiveColor
+                  //     : buttonInnactiveColor,
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12))),
               onPressed: () {
@@ -800,9 +800,9 @@ class __PageState extends State<_Page> {
             padding: const EdgeInsets.all(8.0),
             child: ElevatedButton(
               style: ElevatedButton.styleFrom(
-                  backgroundColor: shape == NeumorphicShape.convex
-                      ? buttonActiveColor
-                      : buttonInnactiveColor,
+                  // backgroundColor: shape == NeumorphicShape.convex
+                  //     ? buttonActiveColor
+                  //     : buttonInnactiveColor,
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12))),
               onPressed: () {
@@ -822,9 +822,9 @@ class __PageState extends State<_Page> {
             padding: const EdgeInsets.all(8.0),
             child: ElevatedButton(
               style: ElevatedButton.styleFrom(
-                  backgroundColor: shape == NeumorphicShape.flat
-                      ? buttonActiveColor
-                      : buttonInnactiveColor,
+                  // backgroundColor: shape == NeumorphicShape.flat
+                  //     ? buttonActiveColor
+                  //     : buttonInnactiveColor,
                   shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12))),
               onPressed: () {

--- a/example/lib/playground/text_playground.dart
+++ b/example/lib/playground/text_playground.dart
@@ -92,7 +92,7 @@ class __PageState extends State<_Page> {
                     style: ElevatedButton.styleFrom(
                       shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12)),
-                      backgroundColor: Theme.of(context).colorScheme.secondary,
+                      // backgroundColor: Theme.of(context).colorScheme.secondary,
                     ),
                     child: Text(
                       "back",
@@ -150,9 +150,9 @@ class __PageState extends State<_Page> {
                     style: ElevatedButton.styleFrom(
                       shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12)),
-                      backgroundColor: selectedConfiguratorIndex == 0
-                          ? buttonActiveColor
-                          : buttonInnactiveColor,
+                      // backgroundColor: selectedConfiguratorIndex == 0
+                      //     ? buttonActiveColor
+                      //     : buttonInnactiveColor,
                     ),
                     child: Text(
                       "Style",
@@ -178,9 +178,9 @@ class __PageState extends State<_Page> {
                     style: ElevatedButton.styleFrom(
                       shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12)),
-                      backgroundColor: selectedConfiguratorIndex == 1
-                          ? buttonActiveColor
-                          : buttonInnactiveColor,
+                      // backgroundColor: selectedConfiguratorIndex == 1
+                      //     ? buttonActiveColor
+                      //     : buttonInnactiveColor,
                     ),
                     child: Text(
                       "Element",
@@ -257,9 +257,9 @@ class __PageState extends State<_Page> {
               style: ElevatedButton.styleFrom(
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12)),
-                backgroundColor: shape == NeumorphicShape.concave
-                    ? buttonActiveColor
-                    : buttonInnactiveColor,
+                // backgroundColor: shape == NeumorphicShape.concave
+                //     ? buttonActiveColor
+                //     : buttonInnactiveColor,
               ),
               onPressed: () {
                 setState(() {
@@ -280,9 +280,9 @@ class __PageState extends State<_Page> {
               style: ElevatedButton.styleFrom(
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12)),
-                backgroundColor: shape == NeumorphicShape.convex
-                    ? buttonActiveColor
-                    : buttonInnactiveColor,
+                // backgroundColor: shape == NeumorphicShape.convex
+                //     ? buttonActiveColor
+                //     : buttonInnactiveColor,
               ),
               onPressed: () {
                 setState(() {
@@ -303,9 +303,9 @@ class __PageState extends State<_Page> {
               style: ElevatedButton.styleFrom(
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12)),
-                backgroundColor: shape == NeumorphicShape.flat
-                    ? buttonActiveColor
-                    : buttonInnactiveColor,
+                // backgroundColor: shape == NeumorphicShape.flat
+                //     ? buttonActiveColor
+                //     : buttonInnactiveColor,
               ),
               onPressed: () {
                 setState(() {

--- a/example/lib/sample_neumorphic_playground.dart
+++ b/example/lib/sample_neumorphic_playground.dart
@@ -250,9 +250,9 @@ class __PageState extends State<_Page> {
               style: ElevatedButton.styleFrom(
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12)),
-                backgroundColor: shape == NeumorphicShape.concave
-                    ? buttonActiveColor
-                    : buttonInnactiveColor,
+                // backgroundColor: shape == NeumorphicShape.concave
+                //     ? buttonActiveColor
+                //     : buttonInnactiveColor,
               ),
               onPressed: () {
                 setState(() {
@@ -273,9 +273,9 @@ class __PageState extends State<_Page> {
               style: ElevatedButton.styleFrom(
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12)),
-                backgroundColor: shape == NeumorphicShape.convex
-                    ? buttonActiveColor
-                    : buttonInnactiveColor,
+                // backgroundColor: shape == NeumorphicShape.convex
+                //     ? buttonActiveColor
+                //     : buttonInnactiveColor,
               ),
               onPressed: () {
                 setState(() {
@@ -296,9 +296,9 @@ class __PageState extends State<_Page> {
               style: ElevatedButton.styleFrom(
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12)),
-                backgroundColor: shape == NeumorphicShape.flat
-                    ? buttonActiveColor
-                    : buttonInnactiveColor,
+                // backgroundColor: shape == NeumorphicShape.flat
+                //     ? buttonActiveColor
+                //     : buttonInnactiveColor,
               ),
               onPressed: () {
                 setState(() {

--- a/example/lib/samples/credit_card_sample.dart
+++ b/example/lib/samples/credit_card_sample.dart
@@ -324,7 +324,7 @@ class __PageContentState extends State<_PageContent> {
             value: 0,
             onChanged: (value) {
               setState(() {
-                _dotIndex = value!;
+                _dotIndex = value! as int;
               });
             },
             style: NeumorphicRadioStyle(
@@ -344,7 +344,7 @@ class __PageContentState extends State<_PageContent> {
             value: 1,
             onChanged: (value) {
               setState(() {
-                _dotIndex = value!;
+                _dotIndex = value! as int;
               });
             },
             style: NeumorphicRadioStyle(
@@ -364,7 +364,7 @@ class __PageContentState extends State<_PageContent> {
             value: 2,
             onChanged: (value) {
               setState(() {
-                _dotIndex = value!;
+                _dotIndex = value! as int;
               });
             },
             style: NeumorphicRadioStyle(

--- a/example/lib/samples/form_sample.dart
+++ b/example/lib/samples/form_sample.dart
@@ -313,7 +313,7 @@ class _GenderField extends StatelessWidget {
               ),
               value: Gender.MALE,
               child: Icon(Icons.account_box),
-              onChanged: (value) => this.onChanged(value!),
+              onChanged: (value) => this.onChanged(value! as Gender),
             ),
             SizedBox(width: 12),
             NeumorphicRadio(
@@ -324,7 +324,7 @@ class _GenderField extends StatelessWidget {
               ),
               value: Gender.FEMALE,
               child: Icon(Icons.pregnant_woman),
-              onChanged: (value) => this.onChanged(value!),
+              onChanged: (value) => this.onChanged(value! as Gender),
             ),
             SizedBox(width: 12),
             NeumorphicRadio(
@@ -335,7 +335,7 @@ class _GenderField extends StatelessWidget {
               ),
               value: Gender.NON_BINARY,
               child: Icon(Icons.supervised_user_circle),
-              onChanged: (value) => this.onChanged(value!),
+              onChanged: (value) => this.onChanged(value! as Gender),
             ),
             SizedBox(
               width: 18,

--- a/example/lib/samples/widgets_sample.dart
+++ b/example/lib/samples/widgets_sample.dart
@@ -124,7 +124,7 @@ class _ContainersListPageState extends State<WidgetsSample> {
           groupValue: _groupValue,
           onChanged: (value) {
             setState(() {
-              _groupValue = value!;
+              _groupValue = value! as int;
             });
           },
         ),
@@ -144,7 +144,7 @@ class _ContainersListPageState extends State<WidgetsSample> {
           groupValue: _groupValue,
           onChanged: (value) {
             setState(() {
-              _groupValue = value!;
+              _groupValue = value! as int;
             });
           },
         ),
@@ -164,7 +164,7 @@ class _ContainersListPageState extends State<WidgetsSample> {
           groupValue: _groupValue,
           onChanged: (value) {
             setState(() {
-              _groupValue = value!;
+              _groupValue = value! as int;
             });
           },
         ),

--- a/example/lib/widgets/radiobutton/widget_radio_button.dart
+++ b/example/lib/widgets/radiobutton/widget_radio_button.dart
@@ -107,7 +107,7 @@ NeumorphicRadio(
             value: 1991,
             onChanged: (value) {
               setState(() {
-                groupValue = value!;
+                groupValue = value! as int;
               });
             },
             padding: EdgeInsets.all(8.0),
@@ -119,7 +119,7 @@ NeumorphicRadio(
             groupValue: groupValue,
             onChanged: (value) {
               setState(() {
-                groupValue = value!;
+                groupValue = value! as int;
               });
             },
             padding: EdgeInsets.all(8.0),
@@ -131,7 +131,7 @@ NeumorphicRadio(
             value: 2012,
             onChanged: (value) {
               setState(() {
-                groupValue = value!;
+                groupValue = value! as int;
               });
             },
             padding: EdgeInsets.all(8.0),
@@ -197,7 +197,7 @@ NeumorphicRadio(
             value: "A",
             onChanged: (value) {
               setState(() {
-                groupValue = value!;
+                groupValue = value! as String;
               });
             },
             padding: EdgeInsets.all(18.0),
@@ -212,7 +212,7 @@ NeumorphicRadio(
             groupValue: groupValue,
             onChanged: (value) {
               setState(() {
-                groupValue = value!;
+                groupValue = value! as String;
               });
             },
             padding: EdgeInsets.all(18.0),
@@ -227,7 +227,7 @@ NeumorphicRadio(
             value: "C",
             onChanged: (value) {
               setState(() {
-                groupValue = value!;
+                groupValue = value! as String;
               });
             },
             padding: EdgeInsets.all(18.0),
@@ -274,7 +274,7 @@ class _EnabledDisabledWidgetState extends State<_EnabledDisabledWidget> {
             child: Text("First"),
             onChanged: (value) {
               setState(() {
-                groupValue = value!;
+                groupValue = value! as int;
               });
             },
           ),
@@ -292,7 +292,7 @@ class _EnabledDisabledWidgetState extends State<_EnabledDisabledWidget> {
             child: Text("Second"),
             onChanged: (value) {
               setState(() {
-                groupValue = value!;
+                groupValue = value! as int;
               });
             },
           ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.0-234.0.dev <3.0.0'
+  sdk: '>=2.17.0<3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
First at all, thanks for this fork.

Second, I updated all the samples by using the latest stable version of **Flutter**:
- Flutter 3.0.5 • channel stable • https://github.com/flutter/flutter.git
- Framework • revision f1875d570e (4 weeks ago) • 2022-07-13 11:24:16 -0700
- Engine • revision e85ea0e79c
- Tools • Dart 2.17.6 • DevTools 2.12.2

In summary:
- Update the YML to use the version of **Dart** (2.17.x) included in **Flutter**
- Comment all the `backgroundColor` fields
- Cast the `Object` to specific type (`int`, `String` or `Gender`)

I tested it in _MacOS_ (Big Sur 11.6.8, x86_64) and _Linux_ (Kubuntu 22.04, x86_64). Notice that still some errors are shown in the Console/Terminal during execution.